### PR TITLE
Fix the order in which we check for errors in the response

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -222,16 +222,9 @@ class Client
      */
     protected function processResponse(Response $httpResponse)
     {
-        // Build the API response from the HTTP response body.
+        // Attempt to build the API response from the HTTP response body.
         $apiResponse = json_decode($httpResponse->getBody()->getContents());
         $httpResponse->getBody()->rewind(); // Rewind the stream to make future access easier.
-
-        // Check for JSON decoding errors.
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new JsonDecodingException(
-                'JSON error while decoding Heroku API response: ' . json_last_error_msg()
-            );
-        }
 
         // Check for API errors.
         // @see https://devcenter.heroku.com/articles/platform-api-reference#statuses
@@ -243,6 +236,13 @@ class Client
                 empty($apiResponse->id) ? 'no error ID found' : $apiResponse->id,
                 empty($apiResponse->message) ? 'no error message found' : $apiResponse->message
             ));
+        }
+
+        // Check for JSON decoding errors.
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new JsonDecodingException(
+                'JSON error while decoding Heroku API response: ' . json_last_error_msg()
+            );
         }
 
         return $apiResponse;


### PR DESCRIPTION
We need to decode the response JSON so that we can construct the best possible message about any bad HTTP status codes, but we also want to prioritize the HTTP exception over any JSON decoding exception. So now we'll decode, check for HTTP issues, and finally check for JSON decoding issues.