### PR TITLE
Save requests and responses earlier during execution.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -163,19 +163,19 @@ class Client
         // Build the request.
         $request = $this->buildRequest($method, $path, $body, $customHeaders);
 
+        // Store the PSR-7 Request object for future examination and use. Redact the API key
+        // so it isn't unwittingly propagated as a result of this feature.
+        $this->lastHttpRequest = $request->withHeader('Authorization', 'Bearer {REDACTED}');
+
         // Make the API call.
         $response = $this->httpClient->sendRequest($request);
 
+        // Store the PSR-7 Response object for future examination and use. Heroku uses headers
+        // as a secondary communication channel for range, rate limit, and caching information.
+        $this->lastHttpResponse = $response;
+
         // Process the response.
         $apiResponse = $this->processResponse($response);
-
-        // Store the underlying PSR-7 Request and Response objects for future examination and use.
-        // The Request will be useful primarily for debugging interaction attempts; the Response
-        // is sometimes a necessity because Heroku uses headers as a secondary communication
-        // channel for range, rate limit, and caching information. We redact the API key from
-        // the Request so that it doesn't get unwittingly propagated as a result of this feature.
-        $this->lastHttpRequest = $request->withHeader('Authorization', 'Bearer {REDACTED}');
-        $this->lastHttpResponse = $response;
 
         return $apiResponse;
     }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -101,6 +101,27 @@ class ClientTest extends TestCase
         (new HerokuClient(['httpClient' => $mockHttpClient]))->get('some/path');
     }
 
+    public function testBadHttpResponsesCanBeExamined()
+    {
+        // Create an HTTP client that will always return an HTTP 404 error response.
+        $mockHttpClient = new MockHttpClient();
+        $mockHttpClient->addResponse(new Response(404));
+        $heroku = new HerokuClient(['httpClient' => $mockHttpClient]);
+
+        // Attempt an API call.
+        try {
+            $heroku->get('some/path');
+        } catch (BadHttpStatusException $exception) {
+            // Allow execution to continue.
+        }
+
+        // Assert that we can read the expected status code from the response.
+        $this->assertEquals(
+            404,
+            $heroku->getLastHttpResponse()->getStatusCode()
+        );
+    }
+
     public function testDefaultHttpClientIsCreated()
     {
         // Assert that a suitable HTTP client will be created if none is provided at instantiation.


### PR DESCRIPTION
- Stores request and response objects earlier (as soon as they are generated), so that they will be available during more exception-handling cases.
- Specifically tests that `getLastHttpResponse()` returns a PSR-7 Response object when catching a `BadHttpStatusCode` exception.