### PR TITLE
Update dependencies for PHP 7 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,12 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "guzzlehttp/psr7": "^1.0",
+        "guzzlehttp/psr7": "^1.6",
         "php-http/message": "^1.5",
-        "php-http/curl-client": "^1.7",
-        "psr/http-message": "^1.0"
+        "php-http/curl-client": "^1.7|^2.1",
+        "psr/http-message": "^1.0",
+        "php-http/discovery": "^1.10",
+        "http-interop/http-factory-guzzle": "^1.0"
     },
     "require-dev": {
         "php-http/mock-client": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.0",
         "guzzlehttp/psr7": "^1.6",
         "php-http/message": "^1.5",
         "php-http/curl-client": "^1.7|^2.1",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "php-http/message": "^1.5",
         "php-http/curl-client": "^1.7|^2.1",
         "psr/http-message": "^1.0",
-        "php-http/discovery": "^1.10",
         "http-interop/http-factory-guzzle": "^1.0"
     },
     "require-dev": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -9,6 +9,8 @@ use HerokuClient\Exception\JsonEncodingException;
 use HerokuClient\Exception\MissingApiKeyException;
 use Http\Client\Curl\Client as CurlHttpClient;
 use Http\Client\HttpClient;
+use Http\Factory\Guzzle\ResponseFactory;
+use Http\Factory\Guzzle\StreamFactory;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
 use Http\Message\StreamFactory\GuzzleStreamFactory;
 use Psr\Http\Message\RequestInterface;
@@ -261,8 +263,8 @@ class Client
     protected function buildHttpClient()
     {
         return new CurlHttpClient(
-            new GuzzleMessageFactory(),
-            new GuzzleStreamFactory(),
+            new ResponseFactory(),
+            new StreamFactory(),
             $this->curlOptions
         );
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -11,8 +11,6 @@ use Http\Client\Curl\Client as CurlHttpClient;
 use Http\Client\HttpClient;
 use Http\Factory\Guzzle\ResponseFactory;
 use Http\Factory\Guzzle\StreamFactory;
-use Http\Message\MessageFactory\GuzzleMessageFactory;
-use Http\Message\StreamFactory\GuzzleStreamFactory;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 


### PR DESCRIPTION
Modern apps (PHP 7+) require some of the dependencies to be updated in order to be interoperable.

This PR updates the necessary dependencies, and removes the support for PHP 5.