### PR TITLE
Require higher versions of PHP and PHPUnit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /working
 /logs
 composer.lock
+composer.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ sudo: false
 language: php
 
 php:
-  - 5.6
   - 7.0
+  - 7.4
 
 install:
   - composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ sudo: false
 language: php
 
 php:
-  - 7.0
+  - 7.1
+  - 7.2
+  # - 7.3 Affected by https://bugs.xdebug.org/view.php?id=1903
   - 7.4
 
 install:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 A PHP client for the Heroku Platform API, similar to [platform-api](https://github.com/heroku/platform-api) for Ruby and [node-heroku-client](https://github.com/heroku/node-heroku-client) for Node.js. With it you can create and alter Heroku apps, install or remove add-ons, scale resources up and down, and use any other capabilities documented by the [Platform API Reference](https://devcenter.heroku.com/articles/platform-api-reference).
 
 ## Features
-- Reads `HEROKU_API_KEY` for zero-config use
+- Reads `HEROKU_API_KEY` for zero-config use (deprecated)
 - Returns JSON-decoded Heroku API responses
 - Exposes response headers (necessary for some API functionality)
 - Uses a built-in cURL-based HTTP client or one that you provide
@@ -34,7 +34,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 use HerokuClient\Client as HerokuClient;
 
 $heroku = new HerokuClient([
-    'apiKey' => 'my-api-key', // Or set the HEROKU_API_KEY environmental variable
+    'apiKey' => 'my-api-key',
 ]);
 ```
 Find out how many web dynos are currently running:
@@ -59,7 +59,7 @@ $remainingCalls = $heroku->getLastHttpResponse()->getHeaderLine('RateLimit-Remai
 The client can be configured at instantiation with these settings, all of which are optional and have sane defaults:
 ```php
 new HerokuClient([
-    'apiKey' => 'my-api-key',                 // If not set, the client finds HEROKU_API_KEY or fails
+    'apiKey' => 'my-api-key',                 // If not set, the client finds HEROKU_API_KEY (deprecated) or fails
     'baseUrl' => 'http://custom.base.url/',   // Defaults to https://api.heroku.com/
     'httpClient' => $myFavoriteHttpClient,    // Any PSR-18 compatible HTTP client
     'curlOptions' => [                        // Options can be set when using the default HTTP client

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A PHP client for the Heroku Platform API, similar to [platform-api](https://gith
 - Designed around the [PSR-7](http://www.php-fig.org/psr/psr-7/) (Request/Response) and [PSR-18](https://www.php-fig.org/psr/psr-18/) (HTTP client) standards
 
 ## Requirements
-- PHP 7 (For PHP 5.6 use our 1.x branch)
+- PHP 7.1+ (For PHP 5.6 or 7.0 use our 1.x branch)
 - cURL, unless providing an HTTP client without cURL dependencies (such as [Socket Client](http://docs.php-http.org/en/latest/clients/socket-client.html))
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ A PHP client for the Heroku Platform API, similar to [platform-api](https://gith
 - Uses a built-in cURL-based HTTP client or one that you provide
 - Accepts cURL options and custom request headers
 - Throws informative exceptions for authentication, JSON, and HTTP errors
-- Designed around [PSR-7](http://www.php-fig.org/psr/psr-7/) (Request/Response) and [HTTPlug](http://docs.php-http.org/en/latest/httplug/introduction.html) (HttpClient) interfaces
+- Designed around the [PSR-7](http://www.php-fig.org/psr/psr-7/) (Request/Response) and [PSR-18](https://www.php-fig.org/psr/psr-18/) (HTTP client) standards
 
 ## Requirements
-- PHP 5.6 / 7
+- PHP 7 (For PHP 5.6 use our 1.x branch)
 - cURL, unless providing an HTTP client without cURL dependencies (such as [Socket Client](http://docs.php-http.org/en/latest/clients/socket-client.html))
 
 ## Installation
@@ -61,7 +61,7 @@ The client can be configured at instantiation with these settings, all of which 
 new HerokuClient([
     'apiKey' => 'my-api-key',                 // If not set, the client finds HEROKU_API_KEY or fails
     'baseUrl' => 'http://custom.base.url/',   // Defaults to https://api.heroku.com/
-    'httpClient' => $myFavoriteHttpClient,    // Any client implementing HTTPlug's HttpClient interface
+    'httpClient' => $myFavoriteHttpClient,    // Any PSR-18 compatible HTTP client
     'curlOptions' => [                        // Options can be set when using the default HTTP client
         CURLOPT_TIMEOUT => 10,
         CURLOPT_USERAGENT => 'My Agent',
@@ -114,7 +114,7 @@ try {
 - `JsonEncodingException`
 - `MissingApiKeyException`
 
-In addition to exceptions thrown directly from this API client, [standardized exceptions](http://docs.php-http.org/en/latest/httplug/exceptions.html) may bubble up from the HTTPlug client implementation in use.
+In addition to exceptions thrown directly from this API client, [standardized exceptions](https://www.php-fig.org/psr/psr-18/#clientexceptioninterface) may bubble up from the HTTP client.
 
 ## Contributing
 Pull Requests are welcome. Please see our [Contribution Guidelines](CONTRIBUTING.md).

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.1",
         "guzzlehttp/psr7": "^1.0",
         "php-http/message": "^1.5",
         "php-http/curl-client": "^2.1",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": "^7.0",
         "guzzlehttp/psr7": "^1.0",
         "php-http/message": "^1.5",
-        "php-http/curl-client": "^1.7|^2.1",
+        "php-http/curl-client": "^2.1",
         "psr/http-message": "^1.0",
         "http-interop/http-factory-guzzle": "^1.0"
     },
@@ -24,8 +24,8 @@
         "php-http/mock-client": "^1.0",
         "ext-curl": "*",
         "ext-mbstring": "*",
-        "phpunit/phpunit": "^5.7",
-        "phpunit/php-code-coverage": "^4.0"
+        "phpunit/phpunit": "^7.0",
+        "phpunit/php-code-coverage": "^6.0.7"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,12 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.0",
         "guzzlehttp/psr7": "^1.0",
         "php-http/message": "^1.5",
-        "php-http/curl-client": "^1.7",
-        "psr/http-message": "^1.0"
+        "php-http/curl-client": "^1.7|^2.1",
+        "psr/http-message": "^1.0",
+        "http-interop/http-factory-guzzle": "^1.0"
     },
     "require-dev": {
         "php-http/mock-client": "^1.0",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,8 +7,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false">
+         stopOnFailure="false">
     <testsuites>
         <testsuite name="All">
             <directory suffix=".php">./tests/</directory>

--- a/src/Client.php
+++ b/src/Client.php
@@ -38,7 +38,7 @@ class Client
     protected $curlOptions = [];
 
     /**
-     * @var HttpClient $httpClient  Client implementing the HTTPlug interface
+     * @var HttpClient $httpClient  PSR-18 HTTP client
      */
     protected $httpClient;
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -9,8 +9,8 @@ use HerokuClient\Exception\JsonEncodingException;
 use HerokuClient\Exception\MissingApiKeyException;
 use Http\Client\Curl\Client as CurlHttpClient;
 use Http\Client\HttpClient;
-use Http\Message\MessageFactory\GuzzleMessageFactory;
-use Http\Message\StreamFactory\GuzzleStreamFactory;
+use Http\Factory\Guzzle\ResponseFactory;
+use Http\Factory\Guzzle\StreamFactory;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -261,8 +261,8 @@ class Client
     protected function buildHttpClient()
     {
         return new CurlHttpClient(
-            new GuzzleMessageFactory(),
-            new GuzzleStreamFactory(),
+            new ResponseFactory(),
+            new StreamFactory(),
             $this->curlOptions
         );
     }


### PR DESCRIPTION
Per a request from a user running into dependency issues on current Laravel installations, this PR moves to requiring PHP 7. Upgrading to more modern versions of PHPUnit also allowed me to remove a deprecated dependency. As the PHP 7 requirement is a breaking change, when this PR is merged it will be tagged as release 2.0.