### PR TITLE
Bump up guzzlehttp/psr7 to ver 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": "^7.3||^8.0",
-        "guzzlehttp/psr7": "^1.0",
+        "guzzlehttp/psr7": "^2.0",
         "php-http/message": "^1.5",
         "php-http/curl-client": "^2.1",
         "psr/http-message": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": "^7.3||^8.0",
-        "guzzlehttp/psr7": "^2.0",
+        "guzzlehttp/psr7": "^1.0 || ^2.0",
         "php-http/message": "^1.5",
         "php-http/curl-client": "^2.1",
         "psr/http-message": "^1.0",


### PR DESCRIPTION
I've had issue upgrading my project dependencies due to this library not supporting guzzlehttp/psr7 ^2.0, I'm hoping to get this updated.