### PR TITLE
Switch to guzzlehttp/psr7:^2.0 and use its official HTTP factories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": "^7.3||^8.0",
-        "guzzlehttp/psr7": "^1.0",
+        "guzzlehttp/psr7": "^2.0",
         "php-http/message": "^1.5",
         "php-http/curl-client": "^2.1",
         "psr/http-message": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": "^7.3||^8.0",
-        "guzzlehttp/psr7": "^2.2.1",
+        "guzzlehttp/psr7": "^2.0",
         "php-http/message": "^1.5",
         "php-http/curl-client": "^2.1",
         "psr/http-message": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,10 @@
     ],
     "require": {
         "php": "^7.3||^8.0",
-        "guzzlehttp/psr7": "^1.0 || ^2.0",
+        "guzzlehttp/psr7": "^2.2.1",
         "php-http/message": "^1.5",
         "php-http/curl-client": "^2.1",
-        "psr/http-message": "^1.0",
-        "http-interop/http-factory-guzzle": "^1.0"
+        "psr/http-message": "^1.0"
     },
     "require-dev": {
         "php-http/mock-client": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": "^7.3||^8.0",
-        "guzzlehttp/psr7": "^2.0",
+        "guzzlehttp/psr7": "^1.0 || ^2.0",
         "php-http/message": "^1.5",
         "php-http/curl-client": "^2.1",
         "psr/http-message": "^1.0",

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,6 +2,7 @@
 
 namespace HerokuClient;
 
+use GuzzleHttp\Psr7\HttpFactory;
 use GuzzleHttp\Psr7\Request;
 use HerokuClient\Exception\BadHttpStatusException;
 use HerokuClient\Exception\JsonDecodingException;
@@ -9,8 +10,6 @@ use HerokuClient\Exception\JsonEncodingException;
 use HerokuClient\Exception\MissingApiKeyException;
 use Http\Client\Curl\Client as CurlHttpClient;
 use Http\Client\HttpClient;
-use Http\Factory\Guzzle\ResponseFactory;
-use Http\Factory\Guzzle\StreamFactory;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -269,8 +268,8 @@ class Client
     protected function buildHttpClient()
     {
         return new CurlHttpClient(
-            new ResponseFactory(),
-            new StreamFactory(),
+            new HttpFactory(),
+            new HttpFactory(),
             $this->curlOptions
         );
     }


### PR DESCRIPTION
Replaces #25 from @lukasjuhas so that I can push to the branch. I found that attempting an upgrade to v2 of the `guzzlehttp/psr7` package failed for me, due to incompatibility with the `http-interop/http-factory-guzzle` package already required. It turns out that the functionality we used from `http-interop/http-factory-guzzle` is now included in `guzzlehttp/psr7`, so I removed the former and altered the code to expect the latter. Always nice to have one less package dependency.